### PR TITLE
Directly doing mvn clean deploy on master branch only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,11 @@ env:
         - secure: "VY0VNZ2DSroR01YjVItrHed1tdW1XDHw6J1NX2rDO3CyMYSDy0kAWiT1F/G6QfExsGaFbtLRLSIWkpKv2HhIyxr7G3vwegqvaHRDUA+PiY66EYrWcS7SWG5YqCojiucEzQwjFnXPrpvIYVgcxID3P2nfBkeqU4KD0/QSD/JLZF0="
         - secure: "OvB4Ev/6vnVhuQWzjPwnJmT4vY2LL0xdf5RVbRo5n620KyvyOvUjdeoQIQY8glkDCo97mwaheFXQZ7mclgPa+N6UKWAP0NrhGENAxf6rTYUVj+JOhqGcTKXvpSOn1Ce2sxTD3DUtVXTqQSOPzyFj5VPAQG1uERd0gUgu+5SDK3c="
 
+#whitelist branches
+branches:
+    only:
+        - master
+
 before_install:
     - openssl aes-256-cbc -pass pass:$GPG_PASSWORD -in secring.gpg.enc -out secring.gpg -d
     - openssl aes-256-cbc -pass pass:$GPG_PASSWORD -in pubring.gpg.enc -out pubring.gpg -d
@@ -13,9 +18,5 @@ before_install:
     - cp pubring.gpg ~/.gnupg/
 
 script:
-    - mvn clean install
-
-after_success:
-    - mvn -B release:clean release:prepare --settings settings.xml
-    - mvn release:perform --settings settings.xml
+    - mvn clean deploy --settings settings.xml
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.yahoo.xpathproto</groupId>
     <artifactId>xpathproto</artifactId>
-    <version>0.1.2-SNAPSHOT</version>
+    <version>0.1.1</version>
     <packaging>jar</packaging>
 
     <name>xpathproto</name>
@@ -214,6 +214,20 @@
                     <nexusUrl>https://oss.sonatype.org/</nexusUrl>
                     <autoReleaseAfterClose>true</autoReleaseAfterClose>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-gpg-plugin</artifactId>
+                <version>1.5</version>
+                <executions>
+                    <execution>
+                        <id>sign-artifacts</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>sign</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
@sushantk 

Only master branch is whitelisted.
Directly doing mvn clean deploy so the tag will not be cut anymore.